### PR TITLE
Updates for ember 1.13+

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ The component derives from `Ember.TextField`, anything you can do with the input
 
 With the [utilities script](https://github.com/Bluefieldscom/intl-tel-input#utilities-script) included, the `autoFormat` and `autoPlaceholder` options are automatically enabled.
 
+If your ember version is <= 1.12, use Brocfile:
 ```javascript
-// Brocfile.js
+// Brocfile.js (if ember <= 1.12)
 
 var app = new EmberAddon({
 
@@ -43,6 +44,18 @@ var app = new EmberAddon({
     includeUtilsScript: true, // default to false
   },
 
+});
+```
+
+Otherwise, use ember-cli-build.js
+```javascript
+// ember-cli-build.js
+
+var app = new EmberApp(defaults, {
+  // Add options here
+  intlTelInput: {
+    includeUthistilsScript: true,
+  }
 });
 ```
 

--- a/addon/components/intl-tel-input.js
+++ b/addon/components/intl-tel-input.js
@@ -199,17 +199,18 @@ export default Ember.TextField.extend({
   number: Ember.computed('value', 'numberFormat', {
     get: function() {
       if (this.get('hasUtilsScript')) {
+        if (this.get('deferNumber')) { return this.get('deferNumber'); }
         var numberFormat = intlTelInputUtils.numberFormat[this.get('numberFormat')];
         return this.$().intlTelInput('getNumber', numberFormat);
       }
     },
     set: function(key, number) {
       if (typeof number === 'undefined' || number === '') { return; }
-      if (!number.startsWith('+')) { number = '+' + number; }
       if (this.element === null) {
         // schedule to set after element is created
         this.set('deferNumber', number);
       } else {
+        if (!number.startsWith('+')) { number = '+' + number; }
         this.$().intlTelInput('setNumber', number);
       }
     }
@@ -322,6 +323,7 @@ export default Ember.TextField.extend({
         notifyPropertyChange();
         var number = that.get('deferNumber');
         if (number !== null) {
+          if (!number.startsWith('+')) { number = '+' + number; }
           that.$().intlTelInput('setNumber', number);
         }
       });

--- a/addon/components/intl-tel-input.js
+++ b/addon/components/intl-tel-input.js
@@ -210,7 +210,6 @@ export default Ember.TextField.extend({
         // schedule to set after element is created
         this.set('deferNumber', number);
       } else {
-        if (!number.startsWith('+')) { number = '+' + number; }
         this.$().intlTelInput('setNumber', number);
       }
     }
@@ -323,8 +322,8 @@ export default Ember.TextField.extend({
         notifyPropertyChange();
         var number = that.get('deferNumber');
         if (number !== null) {
-          if (!number.startsWith('+')) { number = '+' + number; }
           that.$().intlTelInput('setNumber', number);
+          that.set('deferNumber', null)
         }
       });
     });

--- a/addon/components/intl-tel-input.js
+++ b/addon/components/intl-tel-input.js
@@ -202,7 +202,11 @@ export default Ember.TextField.extend({
         return this.$().intlTelInput('getNumber', numberFormat);
       }
     },
-    set: function() { /* no-op */ }
+    set: function(key, number) {
+      if (typeof number === 'undefined' || number === '') { return; }
+      if (!number.startsWith('+')) { number = '+' + number; }
+      this.$().intlTelInput('setNumber', number);
+    }
   }),
 
   /**

--- a/addon/components/intl-tel-input.js
+++ b/addon/components/intl-tel-input.js
@@ -289,25 +289,28 @@ export default Ember.TextField.extend({
    */
   setupIntlTelInput: Ember.on('didInsertElement', function() {
     var notifyPropertyChange = this.notifyPropertyChange.bind(this, 'value');
+    var that = this;
+    Ember.run.scheduleOnce('afterRender', function() {
 
-    // let Ember be aware of the changes
-    this.$().change(notifyPropertyChange);
+      // let Ember be aware of the changes
+      that.$().change(notifyPropertyChange);
 
-    this.$().intlTelInput({
-      allowExtensions: this.get('allowExtensions'),
-      autoFormat: this.get('autoFormat'),
-      autoHideDialCode: this.get('autoHideDialCode'),
-      autoPlaceholder: this.get('autoPlaceholder'),
-      defaultCountry: this.get('defaultCountry'),
-      geoIpLookup: this.get('geoIpLookup'),
-      nationalMode: this.get('nationalMode'),
-      numberType: this.get('numberType'),
-      onlyCountries: this.get('onlyCountries'),
-      preferredCountries: this.get('preferredCountries'),
-    })
-    .then(function() {
-      // trigger a change after the plugin is initialized to set initial values
-      notifyPropertyChange();
+      that.$().intlTelInput({
+        allowExtensions: that.get('allowExtensions'),
+        autoFormat: that.get('autoFormat'),
+        autoHideDialCode: that.get('autoHideDialCode'),
+        autoPlaceholder: that.get('autoPlaceholder'),
+        defaultCountry: that.get('defaultCountry'),
+        geoIpLookup: that.get('geoIpLookup'),
+        nationalMode: that.get('nationalMode'),
+        numberType: that.get('numberType'),
+        onlyCountries: that.get('onlyCountries'),
+        preferredCountries: that.get('preferredCountries')
+      })
+      .then(function() {
+        // trigger a change after the plugin is initialized to set initial values
+        notifyPropertyChange();
+      });
     });
   }),
 

--- a/addon/components/intl-tel-input.js
+++ b/addon/components/intl-tel-input.js
@@ -8,6 +8,7 @@ export default Ember.TextField.extend({
   tagName: 'input',
   attributeBindings: ['type'],
   type: 'tel',
+  deferNumber: null,
 
   /**
    * When `autoFormat` is enabled, this option will support formatting
@@ -205,7 +206,12 @@ export default Ember.TextField.extend({
     set: function(key, number) {
       if (typeof number === 'undefined' || number === '') { return; }
       if (!number.startsWith('+')) { number = '+' + number; }
-      this.$().intlTelInput('setNumber', number);
+      if (this.element === null) {
+        // schedule to set after element is created
+        this.set('deferNumber', number);
+      } else {
+        this.$().intlTelInput('setNumber', number);
+      }
     }
   }),
 
@@ -314,6 +320,10 @@ export default Ember.TextField.extend({
       .then(function() {
         // trigger a change after the plugin is initialized to set initial values
         notifyPropertyChange();
+        var number = that.get('deferNumber');
+        if (number !== null) {
+          that.$().intlTelInput('setNumber', number);
+        }
       });
     });
   }),


### PR DESCRIPTION
Updated the documentation and script to be compatible (no deprecation warnings) under 1.13. Not yet tested, but should work with Ember 2.0 also.
