### PR TITLE
Compatibility with Ember.1.13.10 deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ The component derives from `Ember.TextField`, anything you can do with the input
 
 With the [utilities script](https://github.com/Bluefieldscom/intl-tel-input#utilities-script) included, the `autoFormat` and `autoPlaceholder` options are automatically enabled.
 
+If your ember version is <= 1.12, use Brocfile:
 ```javascript
-// Brocfile.js
+// Brocfile.js (if ember <= 1.12)
 
 var app = new EmberAddon({
 
@@ -43,6 +44,18 @@ var app = new EmberAddon({
     includeUtilsScript: true, // default to false
   },
 
+});
+```
+
+Otherwise, use ember-cli-build.js
+```javascript
+// ember-cli-build.js
+
+var app = new EmberApp(defaults, {
+  // Add options here
+  intlTelInput: {
+    includeUthistilsScript: true,
+  }
 });
 ```
 

--- a/addon/components/intl-tel-input.js
+++ b/addon/components/intl-tel-input.js
@@ -289,25 +289,28 @@ export default Ember.TextField.extend({
    */
   setupIntlTelInput: Ember.on('didInsertElement', function() {
     var notifyPropertyChange = this.notifyPropertyChange.bind(this, 'value');
+    var that = this;
+    Ember.run.scheduleOnce('afterRender', function() {
 
-    // let Ember be aware of the changes
-    this.$().change(notifyPropertyChange);
+      // let Ember be aware of the changes
+      that.$().change(notifyPropertyChange);
 
-    this.$().intlTelInput({
-      allowExtensions: this.get('allowExtensions'),
-      autoFormat: this.get('autoFormat'),
-      autoHideDialCode: this.get('autoHideDialCode'),
-      autoPlaceholder: this.get('autoPlaceholder'),
-      defaultCountry: this.get('defaultCountry'),
-      geoIpLookup: this.get('geoIpLookup'),
-      nationalMode: this.get('nationalMode'),
-      numberType: this.get('numberType'),
-      onlyCountries: this.get('onlyCountries'),
-      preferredCountries: this.get('preferredCountries'),
-    })
-    .then(function() {
-      // trigger a change after the plugin is initialized to set initial values
-      notifyPropertyChange();
+      that.$().intlTelInput({
+        allowExtensions: that.get('allowExtensions'),
+        autoFormat: that.get('autoFormat'),
+        autoHideDialCode: that.get('autoHideDialCode'),
+        autoPlaceholder: that.get('autoPlaceholder'),
+        defaultCountry: that.get('defaultCountry'),
+        geoIpLookup: that.get('geoIpLookup'),
+        nationalMode: that.get('nationalMode'),
+        numberType: that.get('numberType'),
+        onlyCountries: that.get('onlyCountries'),
+        preferredCountries: that.get('preferredCountries')
+      })
+      .then(function() {
+        // trigger a change after the plugin is initialized to set initial values
+        notifyPropertyChange();
+      });
     });
   }),
 


### PR DESCRIPTION
Updated README for ember 1.12+ (brocfile.js). Schedule the DOM updates to avoid deprecation notices.
