### PR TITLE
Fastboot check for loading bower components

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,15 +6,18 @@ module.exports = {
 
   included: function(app) {
     this._super.included(app);
+    
+    if (process.env.EMBER_CLI_FASTBOOT !== 'true') {
+      var config = app.options.intlTelInput;
 
-    var config = app.options.intlTelInput;
+      if (config && true === config.includeUtilsScript) {
+        app.import(app.bowerDirectory + '/intl-tel-input/lib/libphonenumber/build/utils.js');
+      }
 
-    if (config && true === config.includeUtilsScript) {
-      app.import(app.bowerDirectory + '/intl-tel-input/lib/libphonenumber/build/utils.js');
+      app.import(app.bowerDirectory + '/intl-tel-input/build/js/intlTelInput.js');
+      app.import(app.bowerDirectory + '/intl-tel-input/build/img/flags.png', {destDir: 'assets/images'});
+      app.import(app.bowerDirectory + '/intl-tel-input/build/img/flags@2x.png', {destDir: 'assets/images'});
     }
-
-    app.import(app.bowerDirectory + '/intl-tel-input/build/js/intlTelInput.js');
-    app.import(app.bowerDirectory + '/intl-tel-input/build/img/flags.png', { destDir: 'assets/images' });
-    app.import(app.bowerDirectory + '/intl-tel-input/build/img/flags@2x.png', { destDir: 'assets/images' });
   },
 };
+


### PR DESCRIPTION
Checking for Fastboot environment as when ember runs in fastboot, it doesn't have jQuery
